### PR TITLE
Change the crate-type to cdylib for sonarigo-lv2.

### DIFF
--- a/sonarigo-lv2/Cargo.toml
+++ b/sonarigo-lv2/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Johannes Mueller <github@johannes-mueller.org>"]
 edition = "2018"
 
 [lib]
-crate-type = ["dylib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 lv2 = "0.5"


### PR DESCRIPTION
When I tried to load the `lv2` plugin, I got the error 
```
lilv_lib_open(): error: Failed to open library [...]/.lv2/sonarigo.lv2/libsonarigo_lv2.so (libstd-c32b051c3aafd36c.so: cannot open shared object file: No such file or directory)
```
This was solved by changing the crate-type to [`cdylib`](https://doc.rust-lang.org/reference/linkage.html).