### PR TITLE
updated for compatibility with lv2 0.6.0

### DIFF
--- a/sonarigo-lv2/Cargo.toml
+++ b/sonarigo-lv2/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-lv2 = "0.5"
+lv2 = "0.6"
 lv2-worker = "0.1"
 wmidi = "3.1.0"
 

--- a/sonarigo-lv2/src/lib.rs
+++ b/sonarigo-lv2/src/lib.rs
@@ -94,7 +94,7 @@ impl Plugin for SonarigoLV2 {
         })
     }
 
-    fn run(&mut self, ports: &mut Ports, features: &mut Self::AudioFeatures) {
+    fn run(&mut self, ports: &mut Ports, features: &mut Self::AudioFeatures, _: u32) {
         let mut offset: usize = 0;
 
         for (l, r) in Iterator::zip(ports.out_left.iter_mut(), ports.out_right.iter_mut()) {
@@ -193,11 +193,11 @@ impl Plugin for SonarigoLV2 {
                 }
             ).unwrap();
 
-            object_writer.init(self.urids.patch.property, None,
+            object_writer.init(self.urids.patch.property,
                                self.urids.atom.urid,
                                self.urids.sfzfile.into_general());
 
-            let mut prop_writer = object_writer.init(self.urids.patch.value, None,
+            let mut prop_writer = object_writer.init(self.urids.patch.value,
                                                  self.urids.atom_path, ()).unwrap();
             let test_string = prop_writer.append(self.sfzfile_path.as_ref().unwrap());
 


### PR DESCRIPTION
I had trouble building this with the current `Cargo.toml` so I updated the `lv2` crate to 0.6.0.  The `lv2-atom` crate has split the [ObjectWriter](https://docs.rs/lv2-atom/2.0.0/lv2_atom/object/struct.ObjectWriter.html)'s `init` method into two methods--one that takes a context parameter and one that doesn't, so I removed the explicit `None` values.  Also, the [Plugin](https://docs.rs/lv2-core/3.0.0/lv2_core/plugin/trait.Plugin.html) trait's `run` method now includes a `sample_count` parameter, so I ignored it as in the [example code](https://docs.rs/lv2-core/3.0.0/lv2_core/index.html#example).